### PR TITLE
Add Samsung TV Home Assistant integration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ OPENAI_RESPONSES_API_VERSION=2024-02-15-preview
    - "Turn on the living room lights"
    - "Set the thermostat to 72 degrees"
    - "Play music on Apple TV"
+   - "Launch Netflix on the Samsung TV"
    - "Turn off all lights"
 4. **Receive confirmation** through both text and voice responses
 5. **Chat mode** for general conversation when not issuing device commands
@@ -140,7 +141,7 @@ The application integrates with Home Assistant through:
 ### Supported Device Types
 
 - Lights and switches
-- Media players (Apple TV, etc.)
+- Media players (Apple TV, Samsung TV, etc.)
 - Climate control (thermostats)
 - Sensors and binary sensors
 - Custom automations and scripts

--- a/service/example.env
+++ b/service/example.env
@@ -16,6 +16,6 @@ OPENAI_RESPONSES_API_VERSION=preview
 # Home Assistant configuration
 HOME_ASSISTANT_URL=http://homeassistant.local:8123
 HOME_ASSISTANT_TOKEN=""
-HOME_ASSISTANT_DEVICES=appletv,roborock_s7,laundry_switch
+HOME_ASSISTANT_DEVICES=appletv,samsung_tv,roborock_s7,laundry_switch
 
 OPENAI_BASE_URL=""

--- a/service/src/prompts/HOMEASSISTANT.md
+++ b/service/src/prompts/HOMEASSISTANT.md
@@ -18,6 +18,16 @@ description: "";
 /* … */
 }
 /* … */
+},
+{
+"entity_id": "media_player.samsung_tv",
+"state": "off",
+"attributes": {
+"friendly_name": "Samsung TV",
+description: "";
+/* … */
+}
+/* … */
 }
 ]
 
@@ -81,10 +91,19 @@ All keys are lowercase, all strings are double-quoted.
 **User:** _Launch Spotify_  
 { "url_path": "media_player/play_media", "entity_id": "media_player.appletv", "service_data": { "media_content_type": "app", "media_content_id": "com.spotify.client" } }
 
-**User:** _Open YouTube on Apple TV_  
+**User:** _Open YouTube on Apple TV_
 { "url_path": "media_player/play_media", "entity_id": "media_player.appletv", "service_data": { "media_content_type": "app", "media_content_id": "com.google.ios.youtube" } }
 
-**User:** _Turn on living-room lights_ _(no matching entity)_  
+**User:** _Turn on the Samsung TV_
+{ "url_path": "media_player/turn_on", "entity_id": "media_player.samsung_tv" }
+
+**User:** _Turn off Samsung TV_
+{ "url_path": "media_player/turn_off", "entity_id": "media_player.samsung_tv" }
+
+**User:** _Open YouTube on Samsung TV_
+{ "url_path": "media_player/play_media", "entity_id": "media_player.samsung_tv", "service_data": { "media_content_type": "app", "media_content_id": "com.google.ios.youtube" } }
+
+**User:** _Turn on living-room lights_ _(no matching entity)_
 { "error": "no_match" }
 
 ### User

--- a/service/src/prompts/INTENT.md
+++ b/service/src/prompts/INTENT.md
@@ -4,6 +4,7 @@ Your task is to examine each incoming user message and decide which of the two i
    Typical form: a direct command aimed at smart-home devices.
    Examples:
    • “Turn on Apple TV”
+   • “Turn on Samsung TV”
    • “Turn off the kitchen lights”
    • “Open Netflix”
 


### PR DESCRIPTION
## Summary
- expand Home Assistant prompt examples to cover Samsung TV entities alongside the existing Apple TV guidance
- document Samsung TV commands in the README and sample environment configuration
- update the intent-classification prompt examples to recognize Samsung TV control requests

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e55a303444832ea07bc10bd66cc16b