### PR TITLE
Resolve merge conflicts for Samsung TV support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ OPENAI_RESPONSES_API_VERSION=2024-02-15-preview
    - "Turn on the living room lights"
    - "Set the thermostat to 72 degrees"
    - "Play music on Apple TV"
+   - "Launch Netflix on the Samsung TV"
    - "Turn off all lights"
 4. **Receive confirmation** through both text and voice responses
 5. **Chat mode** for general conversation when not issuing device commands
@@ -140,7 +141,7 @@ The application integrates with Home Assistant through:
 ### Supported Device Types
 
 - Lights and switches
-- Media players (Apple TV, etc.)
+- Media players (Apple TV, Samsung TV, etc.)
 - Climate control (thermostats)
 - Sensors and binary sensors
 - Custom automations and scripts

--- a/service/example.env
+++ b/service/example.env
@@ -16,6 +16,6 @@ OPENAI_RESPONSES_API_VERSION=preview
 # Home Assistant configuration
 HOME_ASSISTANT_URL=http://homeassistant.local:8123
 HOME_ASSISTANT_TOKEN=""
-HOME_ASSISTANT_DEVICES=appletv,roborock_s7,laundry_switch
+HOME_ASSISTANT_DEVICES=appletv,samsung_tv,roborock_s7,laundry_switch
 
 OPENAI_BASE_URL=""

--- a/service/src/prompts/HOMEASSISTANT.md
+++ b/service/src/prompts/HOMEASSISTANT.md
@@ -19,6 +19,17 @@ description: "";
 }
 /* … */
 }
+ 
+{
+"entity_id": "media_player.samsung_tv",
+"state": "off",
+"attributes": {
+"friendly_name": "Samsung TV",
+description: "";
+/* … */
+}
+/* … */
+}
 ]
 
 **WHAT TO DO**
@@ -117,10 +128,22 @@ All keys are lowercase, all strings are double-quoted.
 **User:** _Open Netflix on TV_  
 { "url_path": "media_player/play_media", "entity_id": "media_player.appletv", "service_data": { "media_content_type": "app", "media_content_id": "com.netflix.Netflix" } }
 
-**User:** _Launch Spotify_  
+**User:** _Launch Spotify_
 { "url_path": "media_player/play_media", "entity_id": "media_player.appletv", "service_data": { "media_content_type": "app", "media_content_id": "com.spotify.client" } }
 
-**User:** _Turn on living-room lights_ _(no matching entity)_  
+**User:** _Open YouTube on Apple TV_
+{ "url_path": "media_player/play_media", "entity_id": "media_player.appletv", "service_data": { "media_content_type": "app", "media_content_id": "com.google.ios.youtube" } }
+
+**User:** _Turn on Samsung TV_
+{ "url_path": "media_player/turn_on", "entity_id": "media_player.samsung_tv" }
+
+**User:** _Turn off Samsung TV_
+{ "url_path": "media_player/turn_off", "entity_id": "media_player.samsung_tv" }
+
+**User:** _Open YouTube on Samsung TV_
+{ "url_path": "media_player/play_media", "entity_id": "media_player.samsung_tv", "service_data": { "media_content_type": "app", "media_content_id": "com.google.ios.youtube" } }
+
+**User:** _Turn on living-room lights_ _(no matching entity)_
 { "error": "no_match" }
 
 ### User

--- a/service/src/prompts/INTENT.md
+++ b/service/src/prompts/INTENT.md
@@ -4,6 +4,7 @@ Your task is to examine each incoming user message and decide which of the three
    Typical form: a direct command aimed at smart-home devices.
    Examples:
    • "Turn on Apple TV"
+   • "Turn on Samsung TV"
    • "Turn off the kitchen lights"
    • "Open Netflix"
 


### PR DESCRIPTION
## Summary
- update documentation to mention Samsung TV usage and supported media players
- add Samsung TV to the Home Assistant environment sample and few-shot prompt examples
- expand intent classification examples to cover Samsung TV commands

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e8659ee0d4832e8ed08da619951c5d