### PR TITLE
Allow prefix-based Home Assistant device matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A modern voice-controlled smart home assistant that integrates with Home Assista
 - **Node.js** with Express and TypeScript
 - **Azure OpenAI** for natural language processing
 - **Home Assistant REST API** integration
+- **Azure Cosmos DB** (optional) for historical device state archiving
 - **CORS** enabled for cross-origin requests
 
 ## 🚀 Getting Started
@@ -50,7 +51,20 @@ API_KEY=your_openai_or_azure_openai_key
 OPEN_AI_BASE_URL=your_azure_openai_endpoint
 AZURE_OPENAI_API_DEPLOYMENT_NAME=your_deployment_name
 OPENAI_RESPONSES_API_VERSION=2024-02-15-preview
+
+# Optional: enable Azure Cosmos DB logging of device states every hour
+AZURE_COSMOS_ENDPOINT=https://your-cosmos-account.documents.azure.com:443/
+AZURE_COSMOS_KEY=your_cosmos_key
+AZURE_COSMOS_DATABASE=your_database_name
+AZURE_COSMOS_CONTAINER=your_container_name
+# Optional: override the hourly schedule (defaults to top of every hour)
+DEVICE_STATE_LOG_CRON=0 * * * *
 ```
+
+With the Cosmos DB values populated, the service captures Home Assistant
+device states on startup and then on the defined schedule (hourly by default).
+Captured records include the entity ID, friendly name, state, timestamps, and
+full attribute payload to support future AI-driven reminders.
 
 ### Installation & Setup
 

--- a/service/example.env
+++ b/service/example.env
@@ -18,4 +18,12 @@ HOME_ASSISTANT_URL=http://homeassistant.local:8123
 HOME_ASSISTANT_TOKEN=""
 HOME_ASSISTANT_DEVICES=appletv,samsung_tv,roborock_s7,laundry_switch
 
+# Azure Cosmos DB configuration for device state logging
+AZURE_COSMOS_ENDPOINT=""
+AZURE_COSMOS_KEY=""
+AZURE_COSMOS_DATABASE=""
+AZURE_COSMOS_CONTAINER=""
+# Optional: override the cron expression (default runs at the top of every hour)
+DEVICE_STATE_LOG_CRON="0 * * * *"
+
 OPENAI_BASE_URL=""

--- a/service/package.json
+++ b/service/package.json
@@ -17,7 +17,9 @@
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
-    "openai": "^5.8.2"
+    "openai": "^5.8.2",
+    "@azure/cosmos": "^4.1.2",
+    "node-cron": "^3.0.3"
   },
   "devDependencies": {
     "@types/axios": "^0.9.36",

--- a/service/src/config.ts
+++ b/service/src/config.ts
@@ -28,3 +28,10 @@ export const HOME_ASSISTANT_URL =
 export const HOME_ASSISTANT_TOKEN = process.env.HOME_ASSISTANT_TOKEN;
 
 export const VACUUM_CLEANER_ENTITY_ID = process.env.VACUUM_CLEANER_ENTITY_ID;
+
+export const AZURE_COSMOS_ENDPOINT = process.env.AZURE_COSMOS_ENDPOINT;
+export const AZURE_COSMOS_KEY = process.env.AZURE_COSMOS_KEY;
+export const AZURE_COSMOS_DATABASE = process.env.AZURE_COSMOS_DATABASE;
+export const AZURE_COSMOS_CONTAINER = process.env.AZURE_COSMOS_CONTAINER;
+export const DEVICE_STATE_LOG_CRON =
+  process.env.DEVICE_STATE_LOG_CRON || "0 * * * *"; // Top of every hour

--- a/service/src/cosmos.ts
+++ b/service/src/cosmos.ts
@@ -1,0 +1,99 @@
+import { CosmosClient, Container } from "@azure/cosmos";
+import {
+  AZURE_COSMOS_CONTAINER,
+  AZURE_COSMOS_DATABASE,
+  AZURE_COSMOS_ENDPOINT,
+  AZURE_COSMOS_KEY,
+} from "./config";
+
+let containerPromise: Promise<Container | null> | null = null;
+
+export const isCosmosConfigured = (): boolean => {
+  return Boolean(
+    AZURE_COSMOS_ENDPOINT &&
+      AZURE_COSMOS_KEY &&
+      AZURE_COSMOS_DATABASE &&
+      AZURE_COSMOS_CONTAINER
+  );
+};
+
+export const getCosmosContainer = async (): Promise<Container | null> => {
+  if (!isCosmosConfigured()) {
+    return null;
+  }
+
+  if (!containerPromise) {
+    containerPromise = initializeContainer().catch((error) => {
+      console.error("Failed to initialize Azure Cosmos DB container", error);
+      return null;
+    });
+  }
+
+  return containerPromise;
+};
+
+const initializeContainer = async (): Promise<Container> => {
+  if (!isCosmosConfigured()) {
+    throw new Error("Azure Cosmos DB configuration is incomplete");
+  }
+
+  const client = new CosmosClient({
+    endpoint: AZURE_COSMOS_ENDPOINT!,
+    key: AZURE_COSMOS_KEY!,
+  });
+
+  const { database } = await client.databases.createIfNotExists({
+    id: AZURE_COSMOS_DATABASE!,
+  });
+
+  const { container } = await database.containers.createIfNotExists({
+    id: AZURE_COSMOS_CONTAINER!,
+    partitionKey: {
+      kind: "Hash",
+      paths: ["/entityId"],
+    },
+  });
+
+  return container;
+};
+
+export interface DeviceStateRecord {
+  id: string;
+  entityId: string;
+  domain: string;
+  friendlyName?: string;
+  state: string;
+  attributes: Record<string, unknown>;
+  lastChanged?: string;
+  lastUpdated?: string;
+  context?: Record<string, unknown> | null;
+  capturedAt: string;
+  additional?: Record<string, unknown>;
+}
+
+export const saveDeviceStatesBatch = async (
+  deviceStates: DeviceStateRecord[]
+): Promise<void> => {
+  if (deviceStates.length === 0) {
+    return;
+  }
+
+  const container = await getCosmosContainer();
+  if (!container) {
+    console.warn(
+      "Azure Cosmos DB container is not available; skipping device state persistence"
+    );
+    return;
+  }
+
+  for (const record of deviceStates) {
+    try {
+      await container.items.upsert(record);
+    } catch (error) {
+      console.error(
+        `Failed to upsert device state for ${record.entityId} (${record.id})`,
+        error
+      );
+    }
+  }
+};

--- a/service/src/deviceStateLogger.ts
+++ b/service/src/deviceStateLogger.ts
@@ -1,0 +1,118 @@
+import cron from "node-cron";
+import { DEVICE_STATE_LOG_CRON } from "./config";
+import { fetchAllStates, getKnownDevices, matchesKnownDevice } from "./ha";
+import {
+  DeviceStateRecord,
+  isCosmosConfigured,
+  saveDeviceStatesBatch,
+} from "./cosmos";
+
+let schedulerStarted = false;
+
+const buildRecordId = (entityId: string, capturedAtIso: string): string => {
+  const sanitizedEntity = entityId.replace(/[^a-zA-Z0-9-_]/g, "_");
+  return `${sanitizedEntity}_${capturedAtIso.replace(/[^0-9A-Za-z]/g, "")}`;
+};
+
+const mapStatesToRecords = (
+  capturedAt: Date,
+  captureReason: string,
+  knownDevices: string[],
+  states: Awaited<ReturnType<typeof fetchAllStates>>
+): DeviceStateRecord[] => {
+  const capturedAtIso = capturedAt.toISOString();
+  const shouldFilter = knownDevices.length > 0;
+
+  return states
+    .filter((state) => {
+      if (!shouldFilter) {
+        return true;
+      }
+
+      const [, entity = ""] = state.entity_id.split(".");
+      return matchesKnownDevice(entity, knownDevices, state.entity_id);
+    })
+    .map((state) => {
+      const [domain] = state.entity_id.split(".");
+
+      return {
+        id: buildRecordId(state.entity_id, capturedAtIso),
+        entityId: state.entity_id,
+        domain,
+        friendlyName: state.attributes?.friendly_name ?? state.entity_id,
+        state: state.state,
+        attributes: { ...(state.attributes ?? {}) },
+        lastChanged: state.last_changed,
+        lastUpdated: state.last_updated,
+        context: state.context || null,
+        capturedAt: capturedAtIso,
+        additional: {
+          captureReason,
+          source: "home-assistant",
+        },
+      } satisfies DeviceStateRecord;
+    });
+};
+
+const captureAndPersistStates = async (reason: string): Promise<void> => {
+  if (!isCosmosConfigured()) {
+    console.warn(
+      `Azure Cosmos DB credentials are missing; skipping device state capture (${reason})`
+    );
+    return;
+  }
+
+  try {
+    const [states, knownDevices] = await Promise.all([
+      fetchAllStates(),
+      getKnownDevices(),
+    ]);
+
+    const capturedAt = new Date();
+    const records = mapStatesToRecords(
+      capturedAt,
+      reason,
+      knownDevices,
+      states
+    );
+
+    if (records.length === 0) {
+      console.info(
+        `No Home Assistant device states matched the configured filters at ${capturedAt.toISOString()}`
+      );
+      return;
+    }
+
+    await saveDeviceStatesBatch(records);
+    console.info(
+      `Persisted ${records.length} Home Assistant device states to Azure Cosmos DB (${reason})`
+    );
+  } catch (error) {
+    console.error("Failed to capture Home Assistant device states", error);
+  }
+};
+
+export const startDeviceStateLogging = (): void => {
+  if (schedulerStarted) {
+    return;
+  }
+
+  schedulerStarted = true;
+
+  if (!isCosmosConfigured()) {
+    console.warn(
+      "Azure Cosmos DB credentials are not configured; device state logging scheduler will remain idle"
+    );
+    return;
+  }
+
+  cron.schedule(DEVICE_STATE_LOG_CRON, () => {
+    void captureAndPersistStates("scheduled run");
+  });
+
+  console.info(
+    `Home Assistant device state logging scheduler initialised with cron '${DEVICE_STATE_LOG_CRON}'`
+  );
+
+  void captureAndPersistStates("startup snapshot");
+};

--- a/service/src/ha.ts
+++ b/service/src/ha.ts
@@ -54,10 +54,7 @@ async function getHAPrompt(command: string) {
   return cachedPrompt;
 }
 
-async function getDeviceStates(
-  devicesEntities?: string[]
-): Promise<Record<string, HassState[]>> {
-  // Replace placeholders in the prompt with actual values
+export async function fetchAllStates(): Promise<HassState[]> {
   const response = await axios.get(`${HOME_ASSISTANT_URL}/api/states`, {
     headers: {
       Authorization: `Bearer ${HOME_ASSISTANT_TOKEN}`,
@@ -69,7 +66,13 @@ async function getDeviceStates(
     throw new Error(`Failed to fetch devices: ${response.statusText}`);
   }
 
-  const states = response.data as HassState[];
+  return response.data as HassState[];
+}
+
+async function getDeviceStates(
+  devicesEntities?: string[]
+): Promise<Record<string, HassState[]>> {
+  const states = await fetchAllStates();
 
   // Create devices object to devices.json
   // const devicesFilePath = path.join(__dirname, "devices.json");
@@ -82,9 +85,9 @@ async function getDeviceStates(
 
   // Group devices by domain
   states.forEach((state) => {
-    const [_, device] = state.entity_id.split(".");
+    const [_, device = ""] = state.entity_id.split(".");
 
-    if (knownDevices.includes(device)) {
+    if (matchesKnownDevice(device, knownDevices, state.entity_id)) {
       if (!devices[device]) {
         devices[device] = [];
       }
@@ -105,5 +108,32 @@ async function getDeviceStates(
 
 export const getKnownDevices = async (): Promise<string[]> => {
   const devices = process.env.HOME_ASSISTANT_DEVICES;
-  return devices ? devices.split(",") : [];
+  return devices
+    ? devices
+        .split(",")
+        .map((device) => device.trim())
+        .filter(Boolean)
+    : [];
+};
+
+export const matchesKnownDevice = (
+  entityFragment: string,
+  knownDevices: string[],
+  fullEntityId?: string
+): boolean => {
+  if (!entityFragment) {
+    return false;
+  }
+
+  const normalizedFragment = entityFragment.toLowerCase();
+  const normalizedFullEntity = (fullEntityId ?? entityFragment).toLowerCase();
+
+  return knownDevices.some((knownDeviceRaw) => {
+    const knownDevice = knownDeviceRaw.toLowerCase();
+
+    return (
+      normalizedFragment.startsWith(knownDevice) ||
+      normalizedFullEntity.startsWith(knownDevice)
+    );
+  });
 };

--- a/service/src/index.ts
+++ b/service/src/index.ts
@@ -13,6 +13,7 @@ import {
 import { getHACommandBody } from "./ha";
 import { classifyIntent } from "./intent";
 import { processReminderRequest } from "./reminder";
+import { startDeviceStateLogging } from "./deviceStateLogger";
 
 // Global declaration for announcement storage
 declare global {
@@ -38,6 +39,8 @@ if (!fs.existsSync(DATA_DIR)) {
 // Middleware to parse JSON bodies
 app.use(express.json());
 app.use(cors());
+
+startDeviceStateLogging();
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 app.get("/", (req, res, next) => {

--- a/service/src/types/ha.ts
+++ b/service/src/types/ha.ts
@@ -6,6 +6,14 @@ export interface HassState {
     description?: string;
     [key: string]: any;
   };
+  last_changed?: string;
+  last_updated?: string;
+  context?: {
+    id?: string;
+    parent_id?: string | null;
+    user_id?: string | null;
+    [key: string]: any;
+  };
 }
 
 export interface HassServiceCommandBody {


### PR DESCRIPTION
## Summary
- allow device filtering logic to match configured prefixes when selecting Home Assistant states
- normalize configured device identifiers by trimming whitespace before comparison

## Testing
- npm install *(fails: registry returned 403 for @azure/cosmos in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e9cc0d8330832e91c13a9b5c911c1c