### PR TITLE
Use RTSP camera feed when on-device camera is disabled

### DIFF
--- a/ha-voice-assistant/src/skills/gestures/HandGestureDetector.tsx
+++ b/ha-voice-assistant/src/skills/gestures/HandGestureDetector.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { Hands } from "@mediapipe/hands";
 import { Camera } from "@mediapipe/camera_utils";
+import { isCameraOnDevice } from "../../utils/tvCamera";
 
 interface GestureEvent {
   type: string;
@@ -20,6 +21,7 @@ export default function HandGestureDetector({ active }: HandGestureDetectorProps
   const [recentGestures, setRecentGestures] = useState<GestureEvent[]>([]);
   const [debugMode, setDebugMode] = useState(false);
   const [handDistance, setHandDistance] = useState("Unknown");
+  const [cameraDisabled, setCameraDisabled] = useState(false);
 
   // ALL internal state as refs - NO re-renders
   const handsRef = useRef<Hands | null>(null);
@@ -466,10 +468,22 @@ export default function HandGestureDetector({ active }: HandGestureDetectorProps
       return;
     }
 
+    let cancelled = false;
+
+    // In RTSP mode there is no local camera for hand tracking — skip init.
+    isCameraOnDevice().then((onDevice) => {
+      if (cancelled) return;
+      if (!onDevice) {
+        setCameraDisabled(true);
+        return;
+      }
+      setCameraDisabled(false);
+      initCamera();
+    });
+
+    function initCamera() {
     const videoElement = videoRef.current;
     if (!videoElement) return;
-
-    let cancelled = false;
 
     gestureEngineRef.current = new GestureEngine(handleGestureDetected);
 
@@ -531,6 +545,7 @@ export default function HandGestureDetector({ active }: HandGestureDetectorProps
       cancelled = true;
       cleanupResources();
     }
+    } // end initCamera
 
     return () => {
       cancelled = true;
@@ -615,7 +630,19 @@ export default function HandGestureDetector({ active }: HandGestureDetectorProps
             playsInline
             muted
           />
-          {!active && (
+          {cameraDisabled && (
+            <div className="camera-disabled">
+              <span
+                className="camera-icon"
+                role="img"
+                aria-label="no camera"
+              >
+                📷
+              </span>
+              <p>Gesture detection requires an on-device camera.</p>
+            </div>
+          )}
+          {!active && !cameraDisabled && (
             <div className="camera-disabled">
               <span
                 className="camera-icon"

--- a/ha-voice-assistant/src/utils/tvCamera.ts
+++ b/ha-voice-assistant/src/utils/tvCamera.ts
@@ -1,4 +1,4 @@
-import { httpGet } from "../functions/httpUtils";
+import { httpGet, BASE_URL } from "../functions/httpUtils";
 
 interface ScreenshotCapture {
   dataUrl?: string;
@@ -33,6 +33,10 @@ class TvCameraController {
   private videoElement?: HTMLVideoElement;
   private canvasElement?: HTMLCanvasElement;
   private initPromise?: Promise<void>;
+
+  // RTSP mode state
+  private rtspSessionId?: string;
+  private rtspEventSource?: EventSource;
 
   private isBrowser(): boolean {
     return typeof window !== "undefined" && typeof document !== "undefined";
@@ -117,10 +121,25 @@ class TvCameraController {
     );
   }
 
+  private startRtspSubscription(): void {
+    if (this.rtspEventSource) return;
+
+    this.rtspSessionId = `rtsp-${Date.now()}`;
+    const url = `${BASE_URL}/screenshot/subscribe?sessionId=${encodeURIComponent(this.rtspSessionId)}`;
+    this.rtspEventSource = new EventSource(url);
+
+    this.rtspEventSource.onerror = () => {
+      // EventSource auto-reconnects
+    };
+
+    console.info(`[TV Agentic Flow] RTSP mode — subscribed for session ${this.rtspSessionId}`);
+  }
+
   async ensureCamera(): Promise<void> {
     const onDevice = await fetchCameraOnDevice();
     if (!onDevice) {
-      // RTSP mode — server captures frames; no local camera needed.
+      // RTSP mode — start subscription so the server captures frames.
+      this.startRtspSubscription();
       return;
     }
 
@@ -142,8 +161,7 @@ class TvCameraController {
   async capture(stepIndex: number, compress: boolean = true): Promise<ScreenshotCapture> {
     const onDevice = await fetchCameraOnDevice();
     if (!onDevice) {
-      // RTSP mode — server captures frames directly; nothing to capture locally.
-      return {};
+      return this.captureFromRtsp(stepIndex);
     }
 
     try {
@@ -224,7 +242,7 @@ class TvCameraController {
       if (!base64) {
         throw new Error("Failed to encode the captured frame.");
       }
-      
+
       const sizeKB = Math.round((base64.length * 3) / 4 / 1024);
       console.info(
         `[TV Agentic Flow] Captured screenshot for step ${stepIndex} (${targetWidth}x${targetHeight}, ~${sizeKB}KB${compress ? ', compressed' : ''})`
@@ -245,8 +263,29 @@ class TvCameraController {
     }
   }
 
+  private async captureFromRtsp(stepIndex: number): Promise<ScreenshotCapture> {
+    if (!this.rtspSessionId) {
+      this.startRtspSubscription();
+      // Give ffmpeg a moment to produce the first frame
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+
+    try {
+      const res = await httpGet<{ base64: string; contentType: string }>(
+        `/screenshot/latest?sessionId=${encodeURIComponent(this.rtspSessionId!)}`
+      );
+      const { base64, contentType } = res.data;
+      const dataUrl = `data:${contentType};base64,${base64}`;
+      const sizeKB = Math.round((base64.length * 3) / 4 / 1024);
+      console.info(`[TV Agentic Flow] RTSP screenshot for step ${stepIndex} (~${sizeKB}KB)`);
+      return { dataUrl, base64, contentType };
+    } catch {
+      return { error: "No RTSP screenshot available yet. The camera may still be starting." };
+    }
+  }
+
   isActive(): boolean {
-    return Boolean(this.stream);
+    return Boolean(this.stream) || Boolean(this.rtspEventSource);
   }
 
   async stop(): Promise<void> {
@@ -257,6 +296,14 @@ class TvCameraController {
     }
     if (this.videoElement) {
       this.videoElement.srcObject = null;
+    }
+
+    // Clean up RTSP subscription
+    if (this.rtspEventSource) {
+      this.rtspEventSource.close();
+      this.rtspEventSource = undefined;
+      this.rtspSessionId = undefined;
+      console.info("[TV Agentic Flow] Closed RTSP subscription.");
     }
 
     this.stream = null;

--- a/service/src/index.ts
+++ b/service/src/index.ts
@@ -33,7 +33,7 @@ import { startDeviceStateLogging } from "./deviceStateLogger";
 import { runAgent, getRegisteredAgentTypes } from "./agents/core";
 // Import TV agent to trigger registration via side-effect
 import "./agents/tv/tvAgent";
-import { saveScreenshot } from "./agents/common/screenshotStore";
+import { saveScreenshot, getLatestScreenshot } from "./agents/common/screenshotStore";
 import { isRtspMode, startRtspCapture, stopRtspCapture } from "./agents/common/rtspCapture";
 import { traceRouter } from "./tracing/traceApi";
 // Teaching mode imports - for recording manual steps and fine-tuning data
@@ -327,6 +327,20 @@ app.get("/api/screenshot/subscribe", (req, res) => {
       console.log(`[Screenshot SSE] Client disconnected (session ${sessionId})`);
     });
   }
+});
+
+app.get("/api/screenshot/latest", async (req, res) => {
+  const sessionId = typeof req.query.sessionId === "string" ? req.query.sessionId : undefined;
+  if (!sessionId) {
+    res.status(400).json({ error: "sessionId query param is required" });
+    return;
+  }
+  const result = await getLatestScreenshot(sessionId);
+  if (!result) {
+    res.status(404).json({ error: "No screenshot available" });
+    return;
+  }
+  res.json({ base64: result.base64, contentType: result.contentType });
 });
 
 app.post("/api/screenshot", (req, res) => {


### PR DESCRIPTION
## Summary
- Add `GET /api/screenshot/latest` endpoint to serve RTSP frames from the server's screenshot store
- `tvCamera.ts`: In RTSP mode, manage an SSE subscription to start server-side RTSP capture and fetch frames via the new endpoint
- `HandGestureDetector`: Check camera mode on init; disable gracefully in RTSP mode (hand tracking requires a local camera)

Fixes: `Failed to acquire camera feed: NotFoundError: Requested device not found` when `CAMERA_ON_DEVICE=false`

## Test plan
- [ ] Set `CAMERA_ON_DEVICE=false` and `RTSP_URL` in `.env`, verify TV agent flow uses RTSP screenshots
- [ ] Verify Teaching Mode captures screenshots from RTSP feed
- [ ] Verify HandGestureDetector shows disabled message instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)