### PR TITLE
Add agentic TV control, Realtime API chat, and teaching mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ node_modules/
 
 devices.json
 generated_data/
+
+# ML models (large binary files)
+service/models/

--- a/ha-voice-assistant/src/functions/realtimeChat.ts
+++ b/ha-voice-assistant/src/functions/realtimeChat.ts
@@ -1,0 +1,170 @@
+// Azure OpenAI Realtime API v2 — frontend WebSocket client with PCM16 audio playback
+// Keeps a persistent WebSocket so the same Azure session (and voice) is reused.
+
+let activeWs: WebSocket | null = null;
+let activeAudioCtx: AudioContext | null = null;
+let nextPlayTime = 0;
+
+// Per-request callbacks (replaced on each startRealtimeChat call)
+let currentOnTranscriptDelta: ((delta: string) => void) | undefined;
+let currentOnDone: ((fullText: string) => void) | undefined;
+let currentOnError: ((error: string) => void) | undefined;
+let currentResolve: (() => void) | null = null;
+
+const SAMPLE_RATE = 24000;
+
+function pcm16Base64ToFloat32(base64: string): Float32Array {
+  const binary = atob(base64);
+  const len = binary.length;
+  const samples = new Float32Array(len / 2);
+  for (let i = 0; i < samples.length; i++) {
+    const lo = binary.charCodeAt(i * 2);
+    const hi = binary.charCodeAt(i * 2 + 1);
+    // Little-endian signed 16-bit
+    let val = lo | (hi << 8);
+    if (val >= 0x8000) val -= 0x10000;
+    samples[i] = val / 32768;
+  }
+  return samples;
+}
+
+function playPcm16Chunk(samples: Float32Array): void {
+  if (!activeAudioCtx) return;
+
+  const buffer = activeAudioCtx.createBuffer(1, samples.length, SAMPLE_RATE);
+  buffer.getChannelData(0).set(samples);
+
+  const source = activeAudioCtx.createBufferSource();
+  source.buffer = buffer;
+  source.connect(activeAudioCtx.destination);
+
+  const now = activeAudioCtx.currentTime;
+  if (nextPlayTime < now) {
+    nextPlayTime = now + 0.05; // small lead to avoid underrun
+  }
+  source.start(nextPlayTime);
+  nextPlayTime += buffer.duration;
+}
+
+function handleMessage(event: MessageEvent): void {
+  try {
+    const msg = JSON.parse(event.data);
+
+    switch (msg.type) {
+      case "session_ready":
+        // Session is ready — if there's a pending text, it was already sent in startRealtimeChat
+        break;
+
+      case "audio_delta":
+        if (msg.audio) {
+          const samples = pcm16Base64ToFloat32(msg.audio);
+          playPcm16Chunk(samples);
+        }
+        break;
+
+      case "transcript_delta":
+        currentOnTranscriptDelta?.(msg.text);
+        break;
+
+      case "response_done":
+        currentOnDone?.(msg.fullText || "");
+        currentResolve?.();
+        currentResolve = null;
+        break;
+
+      case "error":
+        console.error("[RealtimeChat] Error:", msg.message);
+        currentOnError?.(msg.message);
+        currentResolve?.();
+        currentResolve = null;
+        break;
+    }
+  } catch (err) {
+    console.error("[RealtimeChat] Error parsing message:", err);
+  }
+}
+
+function ensureAudioContext(): void {
+  if (!activeAudioCtx || activeAudioCtx.state === "closed") {
+    activeAudioCtx = new (window.AudioContext || (window as any).webkitAudioContext)({ sampleRate: SAMPLE_RATE });
+  }
+  nextPlayTime = 0;
+}
+
+function isWsOpen(): boolean {
+  return activeWs !== null && activeWs.readyState === WebSocket.OPEN;
+}
+
+export function stopRealtimeChat(): void {
+  if (activeWs) {
+    if (activeWs.readyState === WebSocket.OPEN || activeWs.readyState === WebSocket.CONNECTING) {
+      activeWs.close();
+    }
+    activeWs = null;
+  }
+  if (activeAudioCtx) {
+    activeAudioCtx.close().catch(() => {});
+    activeAudioCtx = null;
+  }
+  nextPlayTime = 0;
+  currentResolve = null;
+}
+
+export function startRealtimeChat(
+  text: string,
+  onTranscriptDelta?: (delta: string) => void,
+  onDone?: (fullText: string) => void,
+  onError?: (error: string) => void
+): Promise<void> {
+  // Update per-request callbacks
+  currentOnTranscriptDelta = onTranscriptDelta;
+  currentOnDone = onDone;
+  currentOnError = onError;
+
+  ensureAudioContext();
+
+  // Reuse existing connection if still open
+  if (isWsOpen()) {
+    return new Promise<void>((resolve) => {
+      currentResolve = resolve;
+      activeWs!.send(JSON.stringify({ type: "user_text", text }));
+    });
+  }
+
+  // Create new connection
+  return new Promise<void>((resolve) => {
+    currentResolve = resolve;
+
+    const wsUrl = `ws://localhost:3005/api/realtime-chat`;
+    const ws = new WebSocket(wsUrl);
+    activeWs = ws;
+
+    ws.onopen = () => {
+      console.log("[RealtimeChat] Connected to backend proxy");
+    };
+
+    ws.onmessage = (event) => {
+      // On first session_ready, send the pending text
+      try {
+        const msg = JSON.parse(event.data);
+        if (msg.type === "session_ready") {
+          ws.send(JSON.stringify({ type: "user_text", text }));
+        }
+      } catch { /* handled by handleMessage */ }
+
+      handleMessage(event);
+    };
+
+    ws.onerror = (err) => {
+      console.error("[RealtimeChat] WebSocket error:", err);
+      currentOnError?.("WebSocket connection error");
+      currentResolve?.();
+      currentResolve = null;
+    };
+
+    ws.onclose = () => {
+      console.log("[RealtimeChat] WebSocket closed");
+      activeWs = null;
+    };
+  });
+}

--- a/ha-voice-assistant/src/functions/speech.ts
+++ b/ha-voice-assistant/src/functions/speech.ts
@@ -13,6 +13,8 @@ import {
   recordStep,
   setTeachingTimeoutCallback,
 } from "./teaching";
+import { startRealtimeChat } from "./realtimeChat";
+import { messageHistoryManager } from "../utils/sessionManager";
 
 export const processRecognizedText = async (
   text: string,
@@ -215,8 +217,30 @@ export const processRecognizedText = async (
         });
       }
     } else if (intent === Intent.Chat) {
-      // Handle chat intent (if applicable)
-      console.log("Chat intent recognized:", text);
+      let fullTranscript = "";
+
+      await startRealtimeChat(
+        text,
+        (delta) => {
+          fullTranscript += delta;
+        },
+        (finalText) => {
+          const responseText = finalText || fullTranscript || "Chat response received.";
+          handleRecognizedText({
+            sender: "assistant",
+            text: responseText,
+            // No messageToAnnounce — Realtime API audio is already playing
+          });
+          messageHistoryManager.addMessage("assistant", responseText);
+        },
+        (error) => {
+          handleRecognizedText({
+            sender: "assistant",
+            text: `Chat error: ${error}`,
+            messageToAnnounce: "Sorry, I couldn't process that.",
+          });
+        }
+      );
     }
   }
 };

--- a/service/package-lock.json
+++ b/service/package-lock.json
@@ -27,6 +27,7 @@
         "node-cron": "^3.0.3",
         "sharp": "^0.34.4",
         "uuid": "^13.0.0",
+        "ws": "^8.20.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -36,6 +37,7 @@
         "@types/node": "^24.9.2",
         "@types/node-cron": "^3.0.11",
         "@types/uuid": "^10.0.0",
+        "@types/ws": "^8.18.1",
         "nodemon": "^3.1.10",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
@@ -1762,6 +1764,16 @@
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typespec/ts-http-runtime": {
       "version": "0.3.1",
@@ -3913,6 +3925,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",

--- a/service/package.json
+++ b/service/package.json
@@ -35,6 +35,7 @@
     "node-cron": "^3.0.3",
     "sharp": "^0.34.4",
     "uuid": "^13.0.0",
+    "ws": "^8.20.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -44,6 +45,7 @@
     "@types/node": "^24.9.2",
     "@types/node-cron": "^3.0.11",
     "@types/uuid": "^10.0.0",
+    "@types/ws": "^8.18.1",
     "nodemon": "^3.1.10",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"

--- a/service/scripts/gesture_detector.py
+++ b/service/scripts/gesture_detector.py
@@ -1,0 +1,123 @@
+"""
+Open-hand (wave/hi) gesture detector using MediaPipe Hand Landmarker.
+
+Runs as a persistent process. Reads JPEG file paths from stdin (one per line),
+outputs JSON results to stdout. Model loads once at startup.
+
+Usage: python3 gesture_detector.py
+  Then send file paths via stdin, one per line.
+  Output: {"gesture": "open_hand", "confidence": 0.85} or {"gesture": "none"}
+"""
+
+import sys
+import os
+import json
+from datetime import datetime
+import numpy as np
+import mediapipe as mp
+from PIL import Image as PILImage
+
+BaseOptions = mp.tasks.BaseOptions
+HandLandmarker = mp.tasks.vision.HandLandmarker
+HandLandmarkerOptions = mp.tasks.vision.HandLandmarkerOptions
+VisionRunningMode = mp.tasks.vision.RunningMode
+
+MODEL_PATH = os.path.join(os.path.dirname(__file__), "..", "models", "hand_landmarker.task")
+
+options = HandLandmarkerOptions(
+    base_options=BaseOptions(model_asset_path=MODEL_PATH),
+    running_mode=VisionRunningMode.IMAGE,
+    num_hands=1,
+    min_hand_detection_confidence=0.3,
+    min_hand_presence_confidence=0.3,
+)
+
+landmarker = HandLandmarker.create_from_options(options)
+
+
+def detect_open_hand(landmarks) -> dict:
+    """Detect open hand (five fingers spread, like waving or saying hi).
+
+    Each finger is "extended" when its tip is farther from the wrist
+    than its MCP (knuckle) joint — meaning it's straightened out.
+    """
+    wrist = landmarks[0]
+
+    # (tip_index, mcp_index) for each finger
+    fingers = [
+        (4, 2),    # Thumb: tip vs IP joint
+        (8, 5),    # Index: tip vs MCP
+        (12, 9),   # Middle: tip vs MCP
+        (16, 13),  # Ring: tip vs MCP
+        (20, 17),  # Pinky: tip vs MCP
+    ]
+
+    extended = 0
+    for tip_idx, base_idx in fingers:
+        tip = landmarks[tip_idx]
+        base = landmarks[base_idx]
+        tip_dist = ((tip.x - wrist.x) ** 2 + (tip.y - wrist.y) ** 2) ** 0.5
+        base_dist = ((base.x - wrist.x) ** 2 + (base.y - wrist.y) ** 2) ** 0.5
+        if tip_dist > base_dist:
+            extended += 1
+
+    confidence = extended / 5.0
+    if confidence >= 0.8:  # At least 4 of 5 fingers extended
+        return {"gesture": "open_hand", "confidence": round(confidence, 2)}
+    return {"gesture": "none"}
+
+
+def process_frame(path: str) -> dict:
+    """Read image, detect hand landmarks, classify gesture.
+
+    The camera is behind the user facing the TV, so the hand appears
+    small at the bottom of a TV-dominated frame. We try the full image
+    first, then crop to the bottom 40% for a closer look at the hand area.
+    """
+    try:
+        image = mp.Image.create_from_file(path)
+    except Exception:
+        return {"gesture": "none", "error": "cannot read image"}
+
+    # Try full image first
+    result = landmarker.detect(image)
+    if result.hand_landmarks:
+        return detect_open_hand(result.hand_landmarks[0])
+
+    # No hand found — crop bottom 40% where the user's hand would be
+    try:
+        full = image.numpy_view()  # RGB numpy array
+        h = full.shape[0]
+        cropped = np.ascontiguousarray(full[int(h * 0.75):, :, :])
+
+        # Save cropped frame for debugging
+        hands_dir = os.path.join(os.path.dirname(path), "..", "hands")
+        os.makedirs(hands_dir, exist_ok=True)
+        ts = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+        PILImage.fromarray(cropped[:, :, :3]).save(os.path.join(hands_dir, f"{ts}.png"))
+
+        cropped_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=cropped)
+        result = landmarker.detect(cropped_image)
+        if result.hand_landmarks:
+            return detect_open_hand(result.hand_landmarks[0])
+    except Exception:
+        pass
+
+    return {"gesture": "none"}
+
+
+# Main loop: read paths from stdin, write JSON to stdout
+sys.stderr.write("[gesture_detector] ready\n")
+sys.stderr.flush()
+
+for line in sys.stdin:
+    path = line.strip()
+    if not path:
+        continue
+    try:
+        out = process_frame(path)
+    except Exception as e:
+        out = {"gesture": "none", "error": str(e)}
+
+    sys.stdout.write(json.dumps(out) + "\n")
+    sys.stdout.flush()

--- a/service/src/agents/core/agentLoop.ts
+++ b/service/src/agents/core/agentLoop.ts
@@ -1,20 +1,19 @@
 /**
- * Agent Loop — wrapper around AI SDK's ToolLoopAgent
+ * Agent Loop — wrapper around AI SDK's generateText with maxSteps
  *
  * Key design:
- * - Tools WITH execute functions: auto-loop inside ToolLoopAgent
+ * - Tools WITH execute functions: auto-loop inside generateText
  * - Tools WITHOUT execute (e.g. get_latest_screenshot): loop breaks, returns to caller
- * - complete_task: stop condition via hasToolCall
+ * - complete_task: no execute function, so it naturally breaks the loop
  * - Session stores messages so the orchestrator can resume after external input
  */
 
 import { randomUUID } from "crypto";
 import {
-  ToolLoopAgent,
+  generateText,
   tool,
   jsonSchema,
   stepCountIs,
-  hasToolCall,
 } from "ai";
 import type {
   ModelMessage,
@@ -39,7 +38,7 @@ export interface ToolDefinition {
     inputSchema?: z.ZodType;
   };
   /**
-   * If provided, the tool auto-executes inside the ToolLoopAgent loop.
+   * If provided, the tool auto-executes inside the generateText loop.
    * If omitted, the loop breaks and returns the tool call to the caller
    * (used for tools that need external input like screenshots).
    */
@@ -107,7 +106,7 @@ export interface AgentLoop {
   ): AgentLoopSession;
   deleteSession(sessionId: string): void;
   /**
-   * Run the agent. The ToolLoopAgent handles the full tool loop internally.
+   * Run the agent. generateText with maxSteps handles the tool loop.
    * Returns when:
    * - complete_task is called → type: "complete"
    * - a tool without execute is invoked → type: "tool_calls"
@@ -184,7 +183,7 @@ export function createAgentLoop(config: AgentLoopConfig): AgentLoop {
     }
   }
 
-  // complete_task tool — always without execute so it triggers hasToolCall stop
+  // complete_task tool — no execute, so generateText loop breaks when it's called
   aiTools["complete_task"] = tool({
     description:
       "Call this tool when you have completed the user's request. Provide a summary.",
@@ -204,33 +203,8 @@ export function createAgentLoop(config: AgentLoopConfig): AgentLoop {
     } as any),
   });
 
-  // Track which session is currently running so onStepFinish can snapshot messages
-  let activeRunSessionId: string | null = null;
-
-  const agent = new ToolLoopAgent({
-    model: azureProvider(model ?? ""),
-    tools: aiTools,
-    instructions: config.systemPrompt,
-    stopWhen: [
-      stepCountIs(maxIterations),
-      hasToolCall("complete_task"),
-    ],
-    onStepFinish: config.onStepFinish
-      ? ({ stepNumber, text, toolCalls, finishReason }) => {
-          const currentSession = activeRunSessionId ? sessions.get(activeRunSessionId) : undefined;
-          config.onStepFinish!({
-            stepNumber,
-            text: text || "",
-            toolCalls: (toolCalls || []).map((tc) => ({
-              toolName: tc.toolName,
-              args: (tc as { input?: unknown }).input,
-            })),
-            finishReason: finishReason || "unknown",
-            messages: currentSession ? [...currentSession.messages] : [],
-          });
-        }
-      : undefined,
-  });
+  // Step counter for onStepFinish callback
+  let stepCounter = 0;
 
   // ---- Session management ----
 
@@ -278,15 +252,32 @@ export function createAgentLoop(config: AgentLoopConfig): AgentLoop {
     }
 
     try {
-      activeRunSessionId = sessionId;
-      const result = await agent.generate({
+      stepCounter = 0;
+      const result = await generateText({
+        model: azureProvider(model ?? ""),
+        tools: aiTools,
+        system: config.systemPrompt,
         messages: session.messages,
+        stopWhen: stepCountIs(maxIterations),
+        onStepFinish: config.onStepFinish
+          ? ({ text, toolCalls, finishReason }) => {
+              stepCounter++;
+              config.onStepFinish!({
+                stepNumber: stepCounter,
+                text: text || "",
+                toolCalls: (toolCalls || []).map((tc) => ({
+                  toolName: tc.toolName,
+                  args: (tc as { input?: unknown }).input,
+                })),
+                finishReason: finishReason || "unknown",
+                messages: [...session.messages],
+              });
+            }
+          : undefined,
       });
-      activeRunSessionId = null;
 
-      return processResult(session, result as GenerateResultShape);
+      return processResult(session, result as unknown as GenerateResultShape);
     } catch (error) {
-      activeRunSessionId = null;
       console.error("[AgentLoop] Error in run:", error);
       return {
         type: "error",

--- a/service/src/config.ts
+++ b/service/src/config.ts
@@ -36,6 +36,17 @@ export const AI_MODEL_ADVANCED = process.env.AI_MODEL_ADVANCED ?? process.env.AI
 export const EMBEDDING_MODEL =
   process.env.EMBEDDING_MODEL ?? "text-embedding-ada-002";
 
+/** Realtime: voice chat via Azure OpenAI Realtime API v2 */
+export const AI_MODEL_REALTIME = process.env.AI_MODEL_REALTIME;
+export const AZURE_OPENAI_REALTIME_API_VERSION =
+  process.env.AZURE_OPENAI_REALTIME_API_VERSION ?? "2025-04-01-preview";
+
+// ============================================================================
+// User / Location
+// ============================================================================
+
+export const USER_ADDRESS = process.env.USER_ADDRESS;
+
 // ============================================================================
 // Azure Speech Service
 // ============================================================================

--- a/service/src/gestureMonitor.ts
+++ b/service/src/gestureMonitor.ts
@@ -1,0 +1,173 @@
+/**
+ * Gesture Monitor
+ *
+ * Watches RTSP camera frames for fist gestures using a persistent
+ * Python + MediaPipe process. When a fist is detected, toggles
+ * TV play/pause via Home Assistant.
+ *
+ * Requires: python3, mediapipe, opencv-python-headless
+ */
+
+import { spawn, ChildProcess } from "child_process";
+import * as path from "path";
+import * as fs from "fs";
+import * as readline from "readline";
+import { startRtspCapture, stopRtspCapture, isRtspMode } from "./agents/common/rtspCapture";
+import { callHAServiceDirect } from "./ha";
+
+const GESTURE_SESSION_ID = "gesture-monitor";
+const FRAME_DIR = path.join(process.cwd(), "out", GESTURE_SESSION_ID);
+const SCRIPT_PATH = path.join(process.cwd(), "scripts", "gesture_detector.py");
+const POLL_INTERVAL_MS = 1000; // Check for new frame every 1s
+const COOLDOWN_MS = 3000; // Prevent rapid toggle
+
+// Entity for play/pause — Apple TV media player
+const MEDIA_PLAYER_ENTITY = "media_player.appletv";
+
+let pythonProc: ChildProcess | null = null;
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+let lastProcessedFrame = "";
+let lastGestureTime = 0;
+let pendingResolve: ((result: GestureResult) => void) | null = null;
+let rl: readline.Interface | null = null;
+
+interface GestureResult {
+  gesture: string;
+  confidence?: number;
+  error?: string;
+}
+
+export function startGestureMonitor(): void {
+  if (!isRtspMode()) {
+    console.log("[Gesture] Skipping — not in RTSP mode");
+    return;
+  }
+
+  if (pythonProc) return;
+
+  // Start dedicated RTSP capture for gesture monitoring
+  startRtspCapture(GESTURE_SESSION_ID).catch((err) => {
+    console.error("[Gesture] Failed to start RTSP capture:", err.message);
+  });
+
+  // Spawn persistent Python process
+  pythonProc = spawn("python3", [SCRIPT_PATH], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  pythonProc.stderr?.on("data", (data: Buffer) => {
+    const msg = data.toString().trim();
+    if (msg) console.log(`[Gesture] ${msg}`);
+  });
+
+  pythonProc.on("error", (err) => {
+    console.error("[Gesture] Python process error:", err.message);
+    pythonProc = null;
+  });
+
+  pythonProc.on("close", (code) => {
+    if (code !== 0) console.error(`[Gesture] Python exited with code ${code}`);
+    pythonProc = null;
+  });
+
+  // Read JSON results line by line from Python stdout
+  rl = readline.createInterface({ input: pythonProc.stdout! });
+  rl.on("line", (line) => {
+    try {
+      const result: GestureResult = JSON.parse(line);
+      if (pendingResolve) {
+        pendingResolve(result);
+        pendingResolve = null;
+      }
+    } catch {
+      // ignore malformed output
+    }
+  });
+
+  // Start polling for new frames
+  pollTimer = setInterval(() => processLatestFrame(), POLL_INTERVAL_MS);
+
+  console.log("[Gesture] Monitor started");
+}
+
+export function stopGestureMonitor(): void {
+  if (pollTimer) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+
+  if (rl) {
+    rl.close();
+    rl = null;
+  }
+
+  if (pythonProc) {
+    pythonProc.kill("SIGTERM");
+    pythonProc = null;
+  }
+
+  stopRtspCapture(GESTURE_SESSION_ID);
+  console.log("[Gesture] Monitor stopped");
+}
+
+function getLatestFrame(): string | null {
+  if (!fs.existsSync(FRAME_DIR)) return null;
+
+  const files = fs.readdirSync(FRAME_DIR)
+    .filter((f) => f.endsWith(".jpg"))
+    .sort()
+    .reverse();
+
+  return files.length > 0 ? path.join(FRAME_DIR, files[0]) : null;
+}
+
+function sendToPython(framePath: string): Promise<GestureResult> {
+  return new Promise((resolve) => {
+    if (!pythonProc || !pythonProc.stdin?.writable) {
+      resolve({ gesture: "none", error: "python not running" });
+      return;
+    }
+
+    pendingResolve = resolve;
+    pythonProc.stdin.write(framePath + "\n");
+
+    // Timeout in case Python hangs
+    setTimeout(() => {
+      if (pendingResolve === resolve) {
+        pendingResolve = null;
+        resolve({ gesture: "none", error: "timeout" });
+      }
+    }, 5000);
+  });
+}
+
+async function processLatestFrame(): Promise<void> {
+  const frame = getLatestFrame();
+  if (!frame || frame === lastProcessedFrame) return;
+
+  lastProcessedFrame = frame;
+
+  const result = await sendToPython(frame);
+
+  if (result.gesture === "open_hand") {
+    const now = Date.now();
+    if (now - lastGestureTime < COOLDOWN_MS) return;
+    lastGestureTime = now;
+
+    console.log(
+      `[Gesture] Open hand detected (confidence=${result.confidence}) — toggling TV play/pause`
+    );
+
+    const res = await callHAServiceDirect(
+      "media_player",
+      "media_play_pause",
+      MEDIA_PLAYER_ENTITY
+    );
+
+    if (res.success) {
+      console.log("[Gesture] TV play/pause toggled");
+    } else {
+      console.error("[Gesture] Failed to toggle TV:", res.message);
+    }
+  }
+}

--- a/service/src/index.ts
+++ b/service/src/index.ts
@@ -35,7 +35,9 @@ import { runAgent, getRegisteredAgentTypes } from "./agents/core";
 import "./agents/tv/tvAgent";
 import { saveScreenshot, getLatestScreenshot } from "./agents/common/screenshotStore";
 import { isRtspMode, startRtspCapture, stopRtspCapture } from "./agents/common/rtspCapture";
+import { startGestureMonitor } from "./gestureMonitor";
 import { traceRouter } from "./tracing/traceApi";
+import { setupRealtimeChatProxy } from "./realtimeChat";
 // Teaching mode imports - for recording manual steps and fine-tuning data
 import {
   startTeachingSession,
@@ -118,6 +120,11 @@ app.get("/traces", (_req, res) => {
 });
 
 startDeviceStateLogging();
+
+// Start gesture monitor for fist-to-pause TV control (RTSP mode only)
+if (isRtspMode()) {
+  startGestureMonitor();
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 app.get("/", (req, res, next) => {
@@ -1831,11 +1838,13 @@ app.post("/api/teaching/cleanup", (req, res, next) => {
   })();
 });
 
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(`Server running on http://localhost:${port}`);
   console.log(`Visit http://localhost:${port} to access the application`);
   console.log(`Telemetry Viewer: http://localhost:${port}/telemetry`);
 });
+
+setupRealtimeChatProxy(server);
 
 // Graceful shutdown
 process.on("SIGTERM", async () => {

--- a/service/src/prompts/INTENT.md
+++ b/service/src/prompts/INTENT.md
@@ -27,15 +27,23 @@ Your task is to examine each incoming user message and decide which of the five 
    • "Train TV agent for playing music on Spotify"
    • "Start teaching mode to navigate to settings"
 
-4. AgenticFlow – A multi-step, on-screen interaction that requires observing the TV interface via camera screenshots (captured by the client device) and issuing several remote control actions (scrolling, selecting apps, entering text, navigating menus, etc.). These requests are NOT direct single-step device commands. They usually sound like tasks that require exploring the UI before finishing.
+4. AgenticFlow – A multi-step, on-screen TV interaction that requires navigating the TV UI via remote control actions (scrolling, selecting apps, entering text, navigating menus, etc.). The request must clearly involve controlling or navigating a TV/streaming app interface. These are NOT general knowledge questions — they are tasks that require exploring the TV UI before finishing.
    Examples:
    • "Play the latest Telugu songs on YouTube"
    • "Find a science fiction movie on Netflix and start playing it"
-   • "Open the weather app on my TV and show today's forecast"
    • "Go to settings and turn on closed captions"
    • "Scroll through Prime Video until you see new releases"
+   • "Search for cooking videos on YouTube"
 
-5. Chat – Any other message meant for open-ended conversation with the chatbot (questions, chit-chat, explanations, etc.).
+5. Chat – Questions, general knowledge, chit-chat, or any conversational message that does NOT involve controlling a smart-home device or navigating a TV interface. This includes questions about weather, news, facts, explanations, opinions, math, and anything else that is purely informational.
+   Examples:
+   • "How is the weather"
+   • "What time is it"
+   • "Tell me a joke"
+   • "What is the capital of France"
+   • "Who won the game last night"
+   • "What should I cook for dinner"
+   • "Explain quantum computing"
 
 ### Successful call
 

--- a/service/src/realtimeChat.ts
+++ b/service/src/realtimeChat.ts
@@ -1,0 +1,368 @@
+import http from "http";
+import WebSocket, { WebSocketServer } from "ws";
+import {
+  AZURE_OPENAI_API_KEY,
+  AZURE_OPENAI_RESOURCE_NAME,
+  AZURE_OPENAI_REALTIME_API_VERSION,
+  AI_MODEL_REALTIME,
+  USER_ADDRESS,
+} from "./config";
+
+// ============================================================================
+// Web Search via DuckDuckGo HTML
+// ============================================================================
+
+const MAX_CONTENT_LENGTH = 4000;
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "")
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "")
+    .replace(/<nav[^>]*>[\s\S]*?<\/nav>/gi, "")
+    .replace(/<footer[^>]*>[\s\S]*?<\/footer>/gi, "")
+    .replace(/<header[^>]*>[\s\S]*?<\/header>/gi, "")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+interface SearchResult {
+  title: string;
+  url: string;
+  snippet: string;
+}
+
+function parseDdgResults(html: string): SearchResult[] {
+  const results: SearchResult[] = [];
+  const resultBlocks = html.split(/class="result\s/);
+
+  for (const block of resultBlocks.slice(1, 6)) {
+    const urlMatch = block.match(/class="result__a"[^>]*href="([^"]+)"/);
+    const titleMatch = block.match(/class="result__a"[^>]*>([^<]+)</);
+    const snippetMatch = block.match(/class="result__snippet"[^>]*>([\s\S]*?)<\/a>/);
+
+    if (urlMatch?.[1]) {
+      let url = urlMatch[1];
+      const uddgMatch = url.match(/uddg=([^&]+)/);
+      if (uddgMatch?.[1]) {
+        url = decodeURIComponent(uddgMatch[1]);
+      }
+
+      results.push({
+        title: titleMatch?.[1]?.trim() || url,
+        url,
+        snippet: snippetMatch?.[1] ? stripHtml(snippetMatch[1]).substring(0, 200) : "",
+      });
+    }
+  }
+
+  return results;
+}
+
+async function fetchPageContent(url: string): Promise<string> {
+  try {
+    const response = await fetch(url, {
+      headers: {
+        "User-Agent": "Mozilla/5.0 (compatible; HAVoiceAssistant/1.0)",
+        Accept: "text/html",
+      },
+      signal: AbortSignal.timeout(8000),
+    });
+
+    if (!response.ok) return "";
+
+    const html = await response.text();
+    let content = html;
+    const mainMatch = html.match(/<main[^>]*>([\s\S]*?)<\/main>/i);
+    const articleMatch = html.match(/<article[^>]*>([\s\S]*?)<\/article>/i);
+    if (mainMatch?.[1]) content = mainMatch[1];
+    else if (articleMatch?.[1]) content = articleMatch[1];
+
+    return stripHtml(content).substring(0, MAX_CONTENT_LENGTH);
+  } catch {
+    return "";
+  }
+}
+
+async function executeWebSearch(query: string): Promise<string> {
+  try {
+    const ddgUrl = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(query)}`;
+    const response = await fetch(ddgUrl, {
+      headers: {
+        "User-Agent": "Mozilla/5.0 (compatible; HAVoiceAssistant/1.0)",
+        Accept: "text/html",
+      },
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (!response.ok) return `Search failed: HTTP ${response.status}`;
+
+    const html = await response.text();
+    const results = parseDdgResults(html);
+
+    if (results.length === 0) return `No results found for "${query}".`;
+
+    const resultsList = results
+      .map((r, i) => `${i + 1}. ${r.title}\n   ${r.url}\n   ${r.snippet}`)
+      .join("\n\n");
+
+    // Fetch top result content for richer context
+    const topContent = await fetchPageContent(results[0].url);
+    const topSection = topContent
+      ? `\n\n--- Top Result Content (${results[0].title}) ---\n${topContent}`
+      : "";
+
+    return `Search results for "${query}":\n\n${resultsList}${topSection}`;
+  } catch (error) {
+    return `Search error: ${error instanceof Error ? error.message : String(error)}`;
+  }
+}
+
+// ============================================================================
+// Persistent Azure Realtime Session
+// ============================================================================
+
+let azureWs: WebSocket | null = null;
+let azureReady = false;
+let activeClientWs: WebSocket | null = null;
+let fullTranscript = "";
+
+function connectAzure(onReady: () => void): void {
+  if (azureWs && azureReady) {
+    onReady();
+    return;
+  }
+
+  // Close stale connection if any
+  if (azureWs) {
+    azureWs.removeAllListeners();
+    if (azureWs.readyState === WebSocket.OPEN || azureWs.readyState === WebSocket.CONNECTING) {
+      azureWs.close();
+    }
+    azureWs = null;
+    azureReady = false;
+  }
+
+  const azureUrl =
+    `wss://${AZURE_OPENAI_RESOURCE_NAME}.openai.azure.com/openai/realtime` +
+    `?api-version=${AZURE_OPENAI_REALTIME_API_VERSION}` +
+    `&deployment=${AI_MODEL_REALTIME}`;
+
+  const ws = new WebSocket(azureUrl, {
+    headers: { "api-key": AZURE_OPENAI_API_KEY! },
+  });
+  azureWs = ws;
+
+  ws.on("open", () => {
+    console.log("[RealtimeChat] Connected to Azure Realtime API");
+
+    // Configure the session with web search tool
+    ws.send(JSON.stringify({
+      type: "session.update",
+      session: {
+        modalities: ["text", "audio"],
+        voice: "alloy",
+        instructions: `You are a helpful home assistant. Be concise and conversational. Keep responses short unless asked for detail. You have a web_search tool — use it when the user asks about current events, facts you're unsure about, or anything that benefits from live information.${USER_ADDRESS ? ` The user's address is: ${USER_ADDRESS}. Use this for location-based queries like weather.` : ""}`,
+        input_audio_format: "pcm16",
+        output_audio_format: "pcm16",
+        turn_detection: null,
+        tools: [
+          {
+            type: "function",
+            name: "web_search",
+            description: "Search the web for current information. Use when the user asks about recent events, news, facts, weather, or anything that needs up-to-date data.",
+            parameters: {
+              type: "object",
+              properties: {
+                query: {
+                  type: "string",
+                  description: "The search query",
+                },
+              },
+              required: ["query"],
+            },
+          },
+        ],
+      },
+    }));
+
+    azureReady = true;
+    onReady();
+  });
+
+  ws.on("message", async (data) => {
+    try {
+      const event = JSON.parse(data.toString());
+
+      switch (event.type) {
+        case "response.audio.delta":
+          activeClientWs?.send(JSON.stringify({
+            type: "audio_delta",
+            audio: event.delta,
+          }));
+          break;
+
+        case "response.audio_transcript.delta":
+          fullTranscript += event.delta;
+          activeClientWs?.send(JSON.stringify({
+            type: "transcript_delta",
+            text: event.delta,
+          }));
+          break;
+
+        case "response.done": {
+          // Only signal done to client if this response produced audio/text
+          // (not when it's a function-call-only response)
+          const hasOutput = event.response?.output?.some(
+            (o: any) => o.type === "message"
+          );
+          if (hasOutput || fullTranscript) {
+            activeClientWs?.send(JSON.stringify({
+              type: "response_done",
+              fullText: fullTranscript,
+            }));
+            fullTranscript = "";
+          }
+          break;
+        }
+
+        case "response.function_call_arguments.done": {
+          const callId = event.call_id;
+          const fnName = event.name;
+          console.log(`[RealtimeChat] Function call: ${fnName}`, event.arguments);
+
+          if (fnName === "web_search") {
+            let query = "";
+            try {
+              const args = JSON.parse(event.arguments);
+              query = args.query || "";
+            } catch {
+              query = "";
+            }
+
+            const searchResult = await executeWebSearch(query);
+            console.log(`[RealtimeChat] Web search completed for: "${query}"`);
+
+            // Send function output back to the conversation
+            ws.send(JSON.stringify({
+              type: "conversation.item.create",
+              item: {
+                type: "function_call_output",
+                call_id: callId,
+                output: searchResult,
+              },
+            }));
+
+            // Trigger response generation with the search results
+            ws.send(JSON.stringify({ type: "response.create" }));
+          }
+          break;
+        }
+
+        case "error":
+          console.error("[RealtimeChat] Azure error:", event.error);
+          activeClientWs?.send(JSON.stringify({
+            type: "error",
+            message: event.error?.message || "Azure Realtime API error",
+          }));
+          break;
+      }
+    } catch (err) {
+      console.error("[RealtimeChat] Error parsing Azure message:", err);
+    }
+  });
+
+  ws.on("error", (err) => {
+    console.error("[RealtimeChat] Azure WS error:", err.message);
+    azureReady = false;
+    activeClientWs?.send(JSON.stringify({
+      type: "error",
+      message: `Azure connection error: ${err.message}`,
+    }));
+  });
+
+  ws.on("close", () => {
+    console.log("[RealtimeChat] Azure WS closed");
+    azureWs = null;
+    azureReady = false;
+  });
+}
+
+// ============================================================================
+// Client WebSocket Handler
+// ============================================================================
+
+export function setupRealtimeChatProxy(server: http.Server): void {
+  if (!AI_MODEL_REALTIME) {
+    console.log("[RealtimeChat] AI_MODEL_REALTIME not set, skipping WebSocket setup");
+    return;
+  }
+
+  const wss = new WebSocketServer({ noServer: true });
+
+  server.on("upgrade", (req, socket, head) => {
+    if (req.url?.startsWith("/api/realtime-chat")) {
+      wss.handleUpgrade(req, socket, head, (ws) => {
+        wss.emit("connection", ws, req);
+      });
+    }
+  });
+
+  wss.on("connection", (clientWs) => {
+    console.log("[RealtimeChat] Client connected");
+    activeClientWs = clientWs;
+
+    // Connect to Azure (reuses existing session if alive)
+    connectAzure(() => {
+      clientWs.send(JSON.stringify({ type: "session_ready" }));
+    });
+
+    clientWs.on("message", (data) => {
+      try {
+        const msg = JSON.parse(data.toString());
+
+        if (msg.type === "user_text" && msg.text && azureWs && azureReady) {
+          fullTranscript = "";
+
+          // Send text as a conversation item
+          azureWs.send(JSON.stringify({
+            type: "conversation.item.create",
+            item: {
+              type: "message",
+              role: "user",
+              content: [{ type: "input_text", text: msg.text }],
+            },
+          }));
+
+          // Trigger response generation
+          azureWs.send(JSON.stringify({ type: "response.create" }));
+        }
+      } catch (err) {
+        console.error("[RealtimeChat] Error parsing client message:", err);
+      }
+    });
+
+    clientWs.on("close", () => {
+      console.log("[RealtimeChat] Client disconnected");
+      if (activeClientWs === clientWs) {
+        activeClientWs = null;
+      }
+      // Keep Azure session alive for next client connection
+    });
+
+    clientWs.on("error", (err) => {
+      console.error("[RealtimeChat] Client WS error:", err.message);
+      if (activeClientWs === clientWs) {
+        activeClientWs = null;
+      }
+    });
+  });
+
+  console.log("[RealtimeChat] WebSocket proxy ready on /api/realtime-chat");
+}


### PR DESCRIPTION
## Summary
- **Agentic TV control**: Generic agent infrastructure with pluggable agent definitions, TV agent with vision-based navigation, deterministic typing, skill system, and flow memory (RAG via Cosmos DB)
- **Azure OpenAI Realtime API v2 for chat**: Persistent WebSocket session with consistent voice, web search tool (DuckDuckGo), and PCM16 audio streaming playback
- **Teaching mode**: Record manual TV navigation steps, generate OpenAI fine-tuning JSONL with screenshots uploaded to Azure Blob Storage
- **Intent classification improvements**: Added Chat examples and tightened AgenticFlow to prevent misrouting general questions
- **RTSP camera support**: Server-side frame capture from RTSP streams, gesture detection for pause control
- **Reminders**: Unified reminder processing with CREATE/LIST/QUERY actions
- **Telemetry**: OpenTelemetry tracing with daily JSONL logs and browser-based trace viewer

## Test plan
- [ ] Start backend (`npm --filter server dev`) and frontend (`npm --filter ha-voice-assistant dev`)
- [ ] Test chat intent: say "how is the weather" — should route to Realtime API, not AgenticFlow
- [ ] Test voice consistency: multiple chat queries should use the same voice
- [ ] Test web search: ask a current events question, verify DuckDuckGo search executes
- [ ] Test TV agent: say "Play latest Telugu songs on YouTube" — should navigate TV UI
- [ ] Test HA commands: say "Turn on Apple TV" — should execute Home Assistant command
- [ ] Test teaching mode: say "Start teaching mode" — should prompt for task name

🤖 Generated with [Claude Code](https://claude.com/claude-code)