### PR TITLE
Fix realtime voice turn reliability after wake-word

### DIFF
--- a/ha-voice-assistant/src/App.tsx
+++ b/ha-voice-assistant/src/App.tsx
@@ -174,6 +174,7 @@ function App() {
   const enterVoiceTurn = useCallback(() => {
     setIsListening(true);
     setIsGestureCameraActive(true);
+    playPing();
     let fullTranscript = "";
     let asyncJobStarted = false;
     startRealtimeVoiceTurn(
@@ -252,24 +253,35 @@ function App() {
         "isListeningForWakeWord:",
         isListeningForWakeWord.current
       );
-      if (
-        finalTranscript.toLocaleLowerCase().includes("assistant") ||
-        finalTranscript.toLocaleLowerCase().includes("hey assistant") ||
-        finalTranscript.toLocaleLowerCase().includes("hey, assistant") ||
-        finalTranscript.toLocaleLowerCase().includes("ok assistant") ||
-        finalTranscript.toLocaleLowerCase().includes("ok, assistant")
-      ) {
-        // If the wake word is detected, reset the transcript and start listening for commands
-        console.log("Wake word detected:", finalTranscript);
+      const lower = finalTranscript.toLocaleLowerCase();
+      const wakeMatch = lower.match(
+        /(?:^|\b)(?:hey[,\s]+|ok[,\s]+)?assistant\b[,.\s]*(.*)$/
+      );
+      if (wakeMatch) {
+        const trailing = wakeMatch[1]?.trim() ?? "";
+        console.log("Wake word detected:", finalTranscript, "trailing:", trailing);
         handleRecognizedText({ sender: "user", text: finalTranscript });
         isListeningForWakeWord.current = false;
         setIsWakeWordMode(false);
 
         SpeechRecognition.abortListening().then(() => {
-          console.log(
-            "SpeechRecognition aborted, starting realtime voice turn..."
-          );
-          enterVoiceTurn();
+          if (trailing) {
+            // User said the question in the same breath as the wake word —
+            // route it via user_text so the realtime API responds immediately,
+            // then resume wake-word listening so the user can talk again.
+            console.log("Routing trailing text as command:", trailing);
+            handleTextCommand(trailing).finally(() => {
+              isListeningForWakeWord.current = true;
+              playPing();
+              startWakeWordListening();
+            });
+          } else {
+            // Bare wake word — open the realtime mic for the next utterance.
+            console.log(
+              "SpeechRecognition aborted, starting realtime voice turn..."
+            );
+            enterVoiceTurn();
+          }
         });
       }
 
@@ -280,6 +292,8 @@ function App() {
     resetTranscript,
     handleRecognizedText,
     enterVoiceTurn,
+    handleTextCommand,
+    startWakeWordListening,
   ]);
 
   const handleOnStartRecognition = () => {

--- a/ha-voice-assistant/src/functions/realtimeChat.ts
+++ b/ha-voice-assistant/src/functions/realtimeChat.ts
@@ -385,7 +385,13 @@ function sendJson(payload: Record<string, unknown>): void {
 async function startMicStreaming(): Promise<void> {
   stopMicStreaming();
 
-  activeMicStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  activeMicStream = await navigator.mediaDevices.getUserMedia({
+    audio: {
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: true,
+    },
+  });
   activeMicCtx = new (window.AudioContext || (window as any).webkitAudioContext)();
   if (activeMicCtx.state === "suspended") {
     await activeMicCtx.resume().catch((error) => {
@@ -395,8 +401,14 @@ async function startMicStreaming(): Promise<void> {
   const source = activeMicCtx.createMediaStreamSource(activeMicStream);
   activeProcessor = activeMicCtx.createScriptProcessor(4096, 1, 1);
 
+  // Drop the first 300ms of captured audio so wake-word residue and the
+  // mic's initial pop don't seed Azure's input buffer.
+  const micOpenedAt = Date.now();
+  const WARMUP_MS = 300;
+
   activeProcessor.onaudioprocess = (event) => {
     if (!isWsOpen() || !activeMicCtx) return;
+    if (Date.now() - micOpenedAt < WARMUP_MS) return;
     const input = event.inputBuffer.getChannelData(0);
     sendJson({
       type: "input_audio",
@@ -539,7 +551,11 @@ export async function startRealtimeVoiceTurn(
     (async () => {
       try {
         await ensureAudioContext();
-        await connectRealtime();
+        const ws = await connectRealtime();
+        // Bare wake-word opens the mic for a real conversation — force the
+        // first response to keep the mic open so the user can actually speak,
+        // even if the model forgets to call await_user_followup.
+        ws.send(JSON.stringify({ type: "force_followup" }));
         await startMicStreaming();
         startListeningWindow(LISTENING_WINDOW_MS);
       } catch (error) {

--- a/service/src/realtimeChat.ts
+++ b/service/src/realtimeChat.ts
@@ -561,7 +561,7 @@ function connectAzure(onReady: () => void): void {
           type: "server_vad",
           threshold: 0.5,
           prefix_padding_ms: 300,
-          silence_duration_ms: 700,
+          silence_duration_ms: 900,
           create_response: true,
           interrupt_response: true,
         },
@@ -711,13 +711,25 @@ function connectAzure(onReady: () => void): void {
           break;
         }
 
-        case "error":
+        case "error": {
+          const errMessage = event.error?.message || "Azure Realtime API error";
           console.error("[RealtimeChat] Azure error:", event.error);
+          // Swallow benign errors from our defensive cleanup on reconnect —
+          // it's expected that there may be no in-flight response or audio
+          // buffer to clear when the session has been idle.
+          if (
+            /no active response/i.test(errMessage) ||
+            /buffer is empty/i.test(errMessage) ||
+            /buffer.*empty/i.test(errMessage)
+          ) {
+            break;
+          }
           sendClient({
             type: "error",
-            message: event.error?.message || "Azure Realtime API error",
+            message: errMessage,
           });
           break;
+        }
       }
     } catch (err) {
       console.error("[RealtimeChat] Error parsing Azure message:", err);
@@ -769,6 +781,16 @@ export function setupRealtimeChatProxy(server: http.Server): void {
     console.log("[RealtimeChat] Client connected");
     activeClientWs = clientWs;
 
+    // Discard any stale state left over from a prior client on the same Azure
+    // session: a response may still be streaming, and the input buffer may
+    // hold unflushed audio. Without this, the new turn inherits the old turn's
+    // tail and "responds" before the user even speaks.
+    if (azureWs && azureReady) {
+      sendAzure({ type: "response.cancel" });
+      sendAzure({ type: "input_audio_buffer.clear" });
+      fullTranscript = "";
+    }
+
     // Connect to Azure (reuses existing session if alive)
     connectAzure(() => {
       clientWs.send(JSON.stringify({ type: "session_ready" }));
@@ -803,6 +825,10 @@ export function setupRealtimeChatProxy(server: http.Server): void {
           console.log("[RealtimeChat] Client requested audio commit");
           azureWs.send(JSON.stringify({ type: "input_audio_buffer.commit" }));
           requestDefaultResponse();
+        } else if (msg.type === "force_followup") {
+          // Client opened the mic for a bare wake-word — keep it open after
+          // the next response no matter what the model decides.
+          pendingFollowUp = true;
         }
       } catch (err) {
         console.error("[RealtimeChat] Error parsing client message:", err);


### PR DESCRIPTION
## Summary
After the wake-word cutover, the realtime voice path had several issues that prevented end-to-end conversations from working — Azure was responding to TV/ambient bleed before the user spoke, the wake-word listener was consuming the user's question along with the wake word, and bare wake-word turns closed before the user got a chance to answer.

- Mic capture now uses `echoCancellation` / `noiseSuppression` / `autoGainControl`, and drops the first 300ms after open so wake-word echo doesn't seed Azure's buffer.
- On client reconnect, the backend now cancels any in-flight Azure response and clears the input audio buffer, with benign cleanup errors swallowed.
- Wake-word detection extracts trailing text and routes it via `user_text` (real response, no realtime-mic race); only bare wake-words open the realtime mic.
- Bare wake-word turns force `pendingFollowUp = true` so the mic stays open after the assistant's greeting (model often forgets to call `await_user_followup`).
- Trailing-text path now restarts wake-word listening when done, so the user doesn't need to re-click Start Voice Assistant.
- Added a start-of-turn `playPing()` so the user gets an audible cue when the mic opens.

## Test plan
- [ ] Restart backend and reload frontend.
- [ ] Say "assistant" alone → expect ping → Azure greets → mic stays open → ask question → real response.
- [ ] Say "assistant how's the weather" in one breath → expect a real weather response (text path), then wake-word listening resumes.
- [ ] Say "assistant resume Apple TV" → expect device action, no "Cancellation failed: no active response" error bubble in chat.
- [ ] Verify TV/ambient noise no longer trips a premature response when only the wake word was spoken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)