### PR TITLE
Make 30s listening window a hard cap from turn activation

### DIFF
--- a/ha-voice-assistant/src/functions/realtimeChat.ts
+++ b/ha-voice-assistant/src/functions/realtimeChat.ts
@@ -223,15 +223,18 @@ async function finishResponse(fullText: string, followupExpected: boolean): Prom
     return;
   }
 
-  // Always keep the mic open for LISTENING_WINDOW_MS after every response so
-  // the user can chain follow-up questions without re-saying the wake word.
-  // followupExpected is ignored here; if the user doesn't speak within the
-  // window, startListeningWindow's timer resolves the turn.
+  // Reopen the mic so the user can keep talking, but DO NOT restart the
+  // listening window — it was started once when the turn was activated and
+  // is a hard 30s cap. Otherwise stray TV/ambient responses would keep
+  // resetting the timer and the session would never close.
   void followupExpected;
+
+  // If the hard cap already expired during the response, the turn was
+  // already resolved by the listening-window timer; nothing more to do.
+  if (voiceTurnResolved) return;
 
   try {
     await startMicStreaming();
-    startListeningWindow(LISTENING_WINDOW_MS);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     currentOnError?.(message);
@@ -278,12 +281,11 @@ function handleMessage(event: MessageEvent): void {
         break;
 
       case "transcript_delta":
-        // Assistant is starting to speak — close the mic and stop the
-        // listening window. finishResponse will reopen both if the assistant's
-        // response is a pending question/confirmation.
+        // Assistant is starting to speak — close the mic so we don't capture
+        // its own output. The listening window is a hard cap from activation
+        // and is intentionally NOT cleared here.
         if (currentMode === "voice") {
           stopMicStreaming();
-          clearListeningWindow();
         }
         currentOnTranscriptDelta?.(msg.text);
         break;
@@ -293,11 +295,8 @@ function handleMessage(event: MessageEvent): void {
         break;
 
       case "user_transcript":
-        // Real user utterance committed — clear the silence timer so it
-        // doesn't expire while the agent processes the command.
-        if (currentMode === "voice" && typeof msg.text === "string" && msg.text.trim()) {
-          clearListeningWindow();
-        }
+        // Hard-cap window is not cleared here either — it counts down from
+        // activation regardless of how many user/assistant exchanges happen.
         currentOnUserTranscript?.(msg.text || "");
         break;
 


### PR DESCRIPTION
## Summary
Previously every response reopened the mic AND restarted the 30s listening window. Stray TV/ambient audio that triggered phantom Azure responses would keep resetting the timer, so the realtime session never closed.

- Start the 30s window once when the voice turn activates; let it count down independently of any responses, transcripts, or assistant speech.
- `finishResponse` still reopens the mic so the user can chain follow-ups, but no longer restarts the timer.
- `transcript_delta` and `user_transcript` handlers no longer clear the window either.

## Caveat
A long TTS response now eats into the user's 30s. If the cap should pause during assistant speech, we can swap to a stopwatch that pauses while a response is in flight.

## Test plan
- [ ] Say "assistant" → ping → mic opens → wait 30s silent → verify the turn closes and wake-word listening resumes.
- [ ] Say "assistant" → ambient TV triggers phantom response → verify the 30s timer is NOT reset; session still closes near the original 30s mark.
- [ ] Say "assistant how's the weather" → text response → mic auto-opens → speak a follow-up → verify timer keeps running from initial activation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)